### PR TITLE
bump evaluate to `0.3.0`

### DIFF
--- a/env.yml
+++ b/env.yml
@@ -19,5 +19,5 @@ dependencies:
   - pip:
     - wandb==0.13.3
     - sentencepiece==0.1.97
-    - evaluate==0.2.2
+    - evaluate==0.3.0
     - sacrebleu==2.2.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.